### PR TITLE
fix: 修复获取已完成模块列表后无法返回主页的问题

### DIFF
--- a/Hamibot/学习强国.js
+++ b/Hamibot/学习强国.js
@@ -346,7 +346,7 @@ var finish_list = get_finish_list();
 // 返回首页
 log("返回首页");
 log("点击:" + "android.view.View");
-className("android.view.View").clickable(true).depth(21).findOne().click();
+className("android.widget.TextView").clickable(true).depth(21).findOne().click();
 log("等待:" + "my_back");
 id("my_back").waitFor();
 sleep(random_time(delay_time / 2));


### PR DESCRIPTION
可能是app改版了，返回首页的回退按钮布局位置改变，导致回退的时候按错，按到了「提醒警示」上。