### PR TITLE
fix: 更换题库下载地址

### DIFF
--- a/Hamibot/学习强国.js
+++ b/Hamibot/学习强国.js
@@ -128,8 +128,8 @@ function map_get(key) {
  */
 if (!storage.contains("answer_question_map1")) {
     toast("正在下载题库");
-    // 使用 Github 文件加速服务：https://git.yumenaka.net
-    var answer_question_bank = http.get("https://git.yumenaka.net/https://raw.githubusercontent.com/Mondayfirst/XXQG_TiKu/main/%E9%A2%98%E5%BA%93_%E6%8E%92%E5%BA%8F%E7%89%88.json");
+    // 使用 Github 文件加速镜像
+    var answer_question_bank = http.get("https://raw.fastgit.org/Mondayfirst/XXQG_TiKu/main/%E9%A2%98%E5%BA%93_%E6%8E%92%E5%BA%8F%E7%89%88.json");
     // 如果资源过期或无法访问则换成别的云盘
     if (!(answer_question_bank.statusCode >= 200 && answer_question_bank.statusCode < 300)) {
         // 使用腾讯云


### PR DESCRIPTION
原来的github文件加速服务down了，导致题库下载出问题。更换新的文件加速镜像地址。