### PR TITLE
更换GitHub加速服务

### DIFF
--- a/Auto.js/学习强国.js
+++ b/Auto.js/学习强国.js
@@ -136,8 +136,8 @@ function map_get(key) {
  * 通过Http下载题库到本地，并进行处理，如果本地已经存在则无需下载
  */
 if (!storage.contains('answer_question_map1')) {
-    // 使用 Github 文件加速服务：https://git.metauniverse-cn.com
-    var answer_question_bank = http.get("https://git.metauniverse-cn.com/https://raw.githubusercontent.com/Mondayfirst/XXQG_TiKu/main/%E9%A2%98%E5%BA%93_%E6%8E%92%E5%BA%8F%E7%89%88.json");
+    // 使用 Github 文件加速服务：https://gh-proxy.com
+    var answer_question_bank = http.get("https://gh-proxy.com/https://raw.githubusercontent.com/Mondayfirst/XXQG_TiKu/main/%E9%A2%98%E5%BA%93_%E6%8E%92%E5%BA%8F%E7%89%88.json");
     // 如果资源过期或无法访问则换成别的云盘
     if (!(answer_question_bank.statusCode >= 200 && answer_question_bank.statusCode < 300)) {
         // 使用腾讯云

--- a/Hamibot/学习强国.js
+++ b/Hamibot/学习强国.js
@@ -128,8 +128,8 @@ function map_get(key) {
  */
 if (!storage.contains("answer_question_map1")) {
     toast("正在下载题库");
-    // 使用 Github 文件加速服务：https://git.metauniverse-cn.com
-    var answer_question_bank = http.get("https://git.metauniverse-cn.com/https://raw.githubusercontent.com/Mondayfirst/XXQG_TiKu/main/%E9%A2%98%E5%BA%93_%E6%8E%92%E5%BA%8F%E7%89%88.json");
+    // 使用 Github 文件加速服务：https://gh-proxy.com
+    var answer_question_bank = http.get("https://gh-proxy.com/https://raw.githubusercontent.com/Mondayfirst/XXQG_TiKu/main/%E9%A2%98%E5%BA%93_%E6%8E%92%E5%BA%8F%E7%89%88.json");
     // 如果资源过期或无法访问则换成别的云盘
     if (!(answer_question_bank.statusCode >= 200 && answer_question_bank.statusCode < 300)) {
         // 使用腾讯云


### PR DESCRIPTION
原地址主也许因为访问量大，限制了文件下载。现更换为加速项目(hunshcn/gh-proxy)原作者提供的加速服务 
https://gh-proxy.com/
有条件的同学可以按作者项目说明，自行搭建加速服务使用。